### PR TITLE
adjusted treesitter parser library path

### DIFF
--- a/miner/src/config.py
+++ b/miner/src/config.py
@@ -54,7 +54,7 @@ SOURCE_CPG_DOCKER = "source-cpg"
 #CPG_DICT = "./cpgdict.txt"
 
 # Treesitter parser library
-PARSER_LIB = f"{CWD}/utils/parsers/build/languages.so"
+PARSER_LIB = f"{CWD}/src/utils/parsers/build/languages.so"
 
 # We cannot use treesitter out-of-the-box since huge file cause problems so
 # that not all functions from a file are being extracted. As a solution we


### PR DESCRIPTION
# Problem Description
The metrics from mcpp cannot be calculated because the treesitter parsers are not found.

# Steps to reproduce
From within the `miner/` directory run:
```
./build.sh
./download.sh
./scripts/scores.sh
```
# Expected Behaviour
The code metrics of mcpp can be calculated.

# Actual Behaviour
The following error occurs when trying to calculate the complexity metrics with mcpp
```OSError: dlopen(.../crashminer/miner/utils/parsers/build/languages.so, 0x0006): tried: '.../crashminer/miner/utils/parsers/build/languages.so' (no such file)```

# Possible Fix
In `build.sh`, the treesitter parsers are downloaded into `src/utils/parsers/` but the treesitter parser path specified in `src/config.py` is `utils/parsers`. 
This PR introduces a possible fix by changing the treesitter parser path in `src/config.py` from `utils/parsers` to `src/utils/parsers`.